### PR TITLE
Fix PHP call-time pass-by-reference error

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -439,7 +439,7 @@ class sspmod_openidProvider_Server {
             'isPassive'=>TRUE
     	);
 
-    	$pc->processStatePassive(&$state);
+    	$pc->processStatePassive($state);
     	$attributes = $state['Attributes'];
 
     	//Process SREG requests


### PR DESCRIPTION
Doing a call-time pass-by-reference is an error now in PHP 5.5. The [method in question](https://github.com/simplesamlphp/simplesamlphp/blob/v1.13.2/lib/SimpleSAML/Auth/ProcessingChain.php#L276) is already set up to use a reference so this change should be harmless.
